### PR TITLE
ci: run main workflow on push to master

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Main
 
 on:
   push:
-    branches: [main]
+    branches: [main, master]
   pull_request:
 
 jobs:


### PR DESCRIPTION
`master` is current default branch of this repo. Subject to change.