### PR TITLE
chore: exclude tooling configuration and tests from published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,14 @@
     "oss"
   ],
   "main": "./lib/index.js",
+  "files": [
+    "bin/",
+    "lib/",
+    "scripts/",
+    "CHANGELOG.md",
+    "NOTICE",
+    "customFormatExample.json"
+  ],
   "bin": {
     "license-checker": "./bin/license-checker"
   },


### PR DESCRIPTION
Omit extraneous files from published package.

### Before

```
npm notice === Tarball Contents ===
npm notice 25B    .eslintignore
npm notice 4B     .nvmrc
npm notice 1.5kB  LICENSE
npm notice 4.2kB  bin/license-checker
npm notice 1.5kB  NOTICE
npm notice 2.2kB  lib/args.js
npm notice 482B   tests/bin-test.js
npm notice 638B   scripts/contrib.js
npm notice 1.6kB  tests/failOn-test.js
npm notice 23.1kB lib/index.js
npm notice 2.1kB  tests/license-files-test.js
npm notice 784B   lib/license-files.js
npm notice 3.2kB  lib/license.js
npm notice 6.5kB  tests/license.js
npm notice 1.7kB  tests/packages-test.js
npm notice 975B   lib/stack.js
npm notice 26.0kB tests/test.js
npm notice 846B   .eslintrc.json
npm notice 45B    tests/.eslintrc.json
npm notice 116B   tests/config/custom_format_broken.json
npm notice 143B   tests/config/custom_format_correct.json
npm notice 171B   customFormatExample.json
npm notice 4.0kB  package.json
npm notice 98B    tests/fixtures/custom-license-file/package.json
npm notice 102B   tests/fixtures/custom-license-url/package.json
npm notice 173B   tests/fixtures/excludeBSD/package.json
npm notice 182B   tests/fixtures/excludePublicDomain/package.json
npm notice 198B   tests/fixtures/excludeWithComma/package.json
npm notice 65B    tests/fixtures/privateModule/package.json
npm notice 57.3kB CHANGELOG.md
npm notice 6.2kB  README.md
npm notice 14B    tests/fixtures/privateModule/README.md
npm notice 181B   .istanbul.yml
npm notice 96B    .travis.yml
npm notice 1.3kB  .github/workflows/main.yml
npm notice 1.0kB  .github/workflows/test.yml
npm notice === Tarball Details ===
npm notice name:          @metamask/license-checker
npm notice version:       26.0.0
npm notice package size:  39.0 kB
npm notice unpacked size: 148.6 kB
```

### After

```
npm notice === Tarball Contents ===
npm notice 57.3kB CHANGELOG.md
npm notice 1.5kB  LICENSE
npm notice 1.5kB  NOTICE
npm notice 6.2kB  README.md
npm notice 4.2kB  bin/license-checker
npm notice 171B   customFormatExample.json
npm notice 2.2kB  lib/args.js
npm notice 23.1kB lib/index.js
npm notice 784B   lib/license-files.js
npm notice 3.2kB  lib/license.js
npm notice 975B   lib/stack.js
npm notice 4.1kB  package.json
npm notice 638B   scripts/contrib.js
npm notice === Tarball Details ===
npm notice name:          @metamask/license-checker
npm notice version:       26.0.0
npm notice filename:      metamask-license-checker-26.0.0.tgz
npm notice package size:  31.1 kB
npm notice unpacked size: 105.8 kB
```